### PR TITLE
Added no-results message for empty search results.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "techsparks-2025",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "techsparks-2025",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/public/script.js
+++ b/public/script.js
@@ -1,9 +1,9 @@
-
 document.addEventListener('DOMContentLoaded', () => {
   const scheduleContainer = document.getElementById('schedule-container');
   const searchBar = document.getElementById('search-bar');
   let talks = [];
 
+  // Fetch talks data from backend
   fetch('/api/talks')
     .then(response => response.json())
     .then(data => {
@@ -11,9 +11,19 @@ document.addEventListener('DOMContentLoaded', () => {
       displayTalks(talks);
     });
 
+  // Function to display talks
   function displayTalks(talksToDisplay) {
     scheduleContainer.innerHTML = '';
     let currentTime = new Date('2025-09-01T10:00:00');
+
+    // ✅ If no talks, show friendly message
+    if (talksToDisplay.length === 0) {
+      const noResultsMessage = document.createElement('p');
+      noResultsMessage.classList.add('no-results');
+      noResultsMessage.textContent = "No talks found for your search.";
+      scheduleContainer.appendChild(noResultsMessage);
+      return;
+    }
 
     talksToDisplay.forEach((talk, index) => {
       const startTime = new Date(currentTime);
@@ -37,17 +47,22 @@ document.addEventListener('DOMContentLoaded', () => {
         const lunchBreakElement = document.createElement('div');
         lunchBreakElement.classList.add('break');
         const lunchEndTime = new Date(currentTime.getTime() + 60 * 60000);
-        lunchBreakElement.innerHTML = `<p><strong>${formatTime(currentTime)} - ${formatTime(lunchEndTime)}</strong></p><h3>Lunch Break</h3>`;
+        lunchBreakElement.innerHTML = `
+          <p><strong>${formatTime(currentTime)} - ${formatTime(lunchEndTime)}</strong></p>
+          <h3>Lunch Break</h3>
+        `;
         scheduleContainer.appendChild(lunchBreakElement);
         currentTime = lunchEndTime;
       }
     });
   }
 
+  // Format time to hh:mm
   function formatTime(date) {
     return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
   }
 
+  // Search filter
   searchBar.addEventListener('input', (e) => {
     const searchTerm = e.target.value.toLowerCase();
     const filteredTalks = talks.filter(talk => 

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,4 +1,3 @@
-
 body {
   background-color: #121212;
   color: #e0e0e0;
@@ -74,6 +73,7 @@ h1 {
   border-radius: 5px;
 }
 
+/* Tumhari branch ka no-results CSS */
 .no-results {
   text-align: center;
   color: gray;
@@ -81,3 +81,9 @@ h1 {
   font-style: italic;
 }
 
+/* Main branch ka loading-indicator CSS */
+#loading-indicator {
+  text-align: center;
+  padding: 40px;
+  font-size: 1.2em;
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -73,3 +73,11 @@ h1 {
   background-color: #222;
   border-radius: 5px;
 }
+
+.no-results {
+  text-align: center;
+  color: gray;
+  margin-top: 20px;
+  font-style: italic;
+}
+


### PR DESCRIPTION
When a search query returns no results, a message 
"No talks found for your search." is displayed instead of showing a blank schedule area.
